### PR TITLE
Add nodemon to development environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "webpack --config webpack.config.js --progress --colors --watch",
     "build": "webpack --config webpack.production.js --progress --colors --bail",
     "postinstall": "bin/heroku",
-    "start": "node app.js"
+    "start": "node app.js",
+    "s": "nodemon app.js"
   },
   "dependencies": {
     "Idle.Js": "git+https://github.com/shawnmclean/Idle.js",
@@ -161,6 +162,7 @@
     "json-loader": "^0.5.4",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
+    "nodemon": "^1.12.1",
     "optimize-css-assets-webpack-plugin": "^1.3.0",
     "script-loader": "^0.7.0",
     "standard": "^9.0.1",


### PR DESCRIPTION
To start the server using [nodemon](https://github.com/remy/nodemon), use:
- `npm run s`