### PR TITLE
Insert new editor toolbar button on navbar

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -803,6 +803,7 @@ function changeMode (type) {
     editor.setOption('foldGutter', true)
   } else {
     ui.toolbar.uploadImage.fadeOut()
+    ui.toolbar.editorToolbar.fadeOut()
   }
   if (appState.currentMode !== modeType.edit) {
     $(document.body).css('background-color', 'white')

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -792,6 +792,7 @@ function changeMode (type) {
   }
   if (appState.currentMode === modeType.edit || appState.currentMode === modeType.both) {
     ui.toolbar.uploadImage.fadeIn()
+    ui.toolbar.editorToolbar.fadeIn()
     // add and update status bar
     if (!editorInstance.statusBar) {
       editorInstance.addStatusBar()

--- a/public/js/lib/editor/ui-elements.js
+++ b/public/js/lib/editor/ui-elements.js
@@ -37,7 +37,8 @@ export const getUIElements = () => ({
     edit: $('.ui-edit'),
     view: $('.ui-view'),
     both: $('.ui-both'),
-    uploadImage: $('.ui-upload-image')
+    uploadImage: $('.ui-upload-image'),
+    editorToolbar: $('.ui-editor-toolbar')
   },
   infobar: {
     lastchange: $('.ui-lastchange'),

--- a/public/views/hackmd/header.ejs
+++ b/public/views/hackmd/header.ejs
@@ -92,13 +92,16 @@
                     <input type="radio" name="mode" autocomplete="off"><i class="fa fa-pencil"></i>
                 </label>
             </div>
+            <span class="btn btn-link btn-file ui-editor-toolbar" title="Editor tools" style="display:none;">
+              <i class="fa fa-header"></i>
+            </span>
             <span class="btn btn-link btn-file ui-help" title="<%= __('Help') %>" data-toggle="modal" data-target=".help-modal">
                 <i class="fa fa-question-circle"></i>
             </span>
             <span class="btn btn-link btn-file ui-upload-image" title="<%= __('Upload Image') %>" style="display:none;">
-                <i class="fa fa-camera"></i><input type="file" accept="image/*" name="upload" multiple>
+              <i class="fa fa-camera"></i><input type="file" accept="image/*" name="upload" multiple>
             </span>
-        </ul>
+          </ul>
         <ul class="nav navbar-nav navbar-right">
             <li id="online-user-list">
                 <a class="ui-status" data-toggle="dropdown">


### PR DESCRIPTION
# Editor Toolbar button
![image](https://user-images.githubusercontent.com/7807555/31339762-51229dce-acda-11e7-9332-f195a3be75f3.png)

As a new use case, the user should be able to see the available options of tags from the navbar.

The button with its icon has been added to the navbar and the next step is to render an editor toolbar with the different text style options